### PR TITLE
Prepare for 3.0.2 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,10 @@ jobs:
           cache: 'sbt'
 
       - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test
+        run: sbt ++${{ matrix.scala }} clean check coverage test
 
       - name: test coverage
         if: success()
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
-
-      - name: slack
-        uses: homoluctus/slatify@master
-        if: failure() && github.ref == 'refs/heads/master'
-        with:
-          type: ${{ job.status }}
-          job_name: Build
-          url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,11 @@
+name: Publish new Release
+
+on:
+  release:
+    types: [published]
+    branches: [main]
+
+jobs:
+  release:
+    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v1
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish new Release
 on:
   release:
     types: [published]
-    branches: [main]
+    branches: [master]
 
 jobs:
   release:

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import Dependencies._
+import Dependencies.*
 
 name := "sharding-strategy"
 
@@ -15,7 +15,8 @@ scalacOptions := Seq(
   "-Xsource:3",
 )
 releaseCrossBuild := true
-publishTo := Some(Resolver.evolutionReleases)
+publishTo := Some(Resolver.evolutionReleases) // sbt-release
+versionPolicyIntention := Compatibility.BinaryCompatible // sbt-version-policy
 
 libraryDependencies ++= Seq(
   `ddata-tools`,
@@ -31,4 +32,7 @@ libraryDependencies ++= Seq(
 
 licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT")))
 
+//addCommandAlias("fmt", "scalafixAll; all scalafmtAll scalafmtSbt")
+//addCommandAlias("check", "scalafixEnable; scalafixAll --check; all versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck")
+addCommandAlias("check", "versionPolicyCheck")
 addCommandAlias("build", "all compile test")

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,12 @@ releaseCrossBuild := true
 publishTo := Some(Resolver.evolutionReleases) // sbt-release
 versionPolicyIntention := Compatibility.BinaryCompatible // sbt-version-policy
 
+// TODO remove after 3.0.2 is released
+versionPolicyIgnored := Seq(
+  "com.evolutiongaming" %% "nel",
+  "com.evolutiongaming" %% "safe-actor",
+)
+
 libraryDependencies ++= Seq(
   `ddata-tools`,
   `cats-helper`,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,9 @@ import sbt._
 
 object Dependencies {
 
-  val scalatest        = "org.scalatest"       %% "scalatest"      % "3.2.18"
-  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"    % "3.10.3"
-  val `ddata-tools`    = "com.evolutiongaming" %% "ddata-tools"    % "4.0.0"
+  val scalatest     = "org.scalatest"       %% "scalatest"   % "3.2.18"
+  val `cats-helper` = "com.evolutiongaming" %% "cats-helper" % "3.10.3"
+  val `ddata-tools` = "com.evolutiongaming" %% "ddata-tools" % "4.0.0"
 
   object Cats {
     private val version = "2.10.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.0.2-SNAPSHOT"
+ThisBuild / version := "3.0.2"


### PR DESCRIPTION
Currently `versionPolicyReportDependencyIssues` fails due to removed dependencies on `nel` and `safe-actore` which were not used.

Only working solution I found so far is to bump major version.